### PR TITLE
fix: heart too small when title is too big

### DIFF
--- a/src/components/01-atoms/BadgeCard.tsx
+++ b/src/components/01-atoms/BadgeCard.tsx
@@ -8,6 +8,7 @@ import {
   Divider,
   Flex,
   Avatar,
+  Box,
 } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 
@@ -74,7 +75,14 @@ export const BadgeCard: React.FC<BadgeCardProps> = ({ badgeData }) => {
             pb="0.75rem"
           >
             <Flex gap={4} className={"items-center"}>
-              <HeartIcon className="w-4 h-4 opacity-50 text-slate-50" />
+              <Box
+                boxSize="24px"
+                display="flex"
+                justifyContent="center"
+                alignItems="center"
+              >
+                <HeartIcon className="w-5 h-5  opacity-50 text-slate-50" />
+              </Box>
               <Text fontSize="md" className="text-slate-50">
                 {badge.title}
               </Text>


### PR DESCRIPTION
As agreed, I did not limit the size of the title, I only added a fixed size to the wrap of the heart icon.

closes #84 