### PR TITLE
fix: Checking correct network before blockchains calls

### DIFF
--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -31,7 +31,7 @@ export default function renderPage({ params }: { params: { slug: [string] } }) {
         notifyError({
           title: "Unsupported network",
           message:
-            "Please switch to the supported network to use this application.",
+            "Please switch to the Optmism network to use this application.",
         });
         switchChain({ chainId: optimism.id });
       }

--- a/src/components/01-atoms/DropdownProfile.tsx
+++ b/src/components/01-atoms/DropdownProfile.tsx
@@ -53,7 +53,7 @@ export const DropdownProfile = ({
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;

--- a/src/components/01-atoms/DropdownProfile.tsx
+++ b/src/components/01-atoms/DropdownProfile.tsx
@@ -13,17 +13,17 @@ import {
   Slide,
 } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
+import { optimism } from "viem/chains";
 import { useDisconnect } from "wagmi";
 import { useAccount, useSwitchChain } from "wagmi";
 
-import { useNotify } from "@/hooks";
 import { AdminIcon, LogoutIcon } from "@/components/01-atoms";
+import { useNotify } from "@/hooks";
 import { ROLES } from "@/lib/client/constants";
 import { hasRole } from "@/lib/service/hasRole";
 import { wagmiConfig } from "@/wagmi";
 
 import { EnsAvatar, EnsName } from "../02-molecules";
-import { optimism } from "viem/chains";
 
 export const DropdownProfile = ({
   isOpenMenu,

--- a/src/components/03-organisms/DropdownMenuAdmin.tsx
+++ b/src/components/03-organisms/DropdownMenuAdmin.tsx
@@ -87,6 +87,7 @@ export const DropdownMenuAdmin = () => {
       });
       return;
     }
+    
     if (chainId !== optimism.id) {
       notifyError({
         title: "Unsupported network",
@@ -170,6 +171,7 @@ export const DropdownMenuAdmin = () => {
       });
       return;
     }
+    
     if (chainId !== optimism.id) {
       notifyError({
         title: "Unsupported network",
@@ -265,6 +267,7 @@ export const DropdownMenuAdmin = () => {
       });
       return;
     }
+    
     if (chainId !== optimism.id) {
       notifyError({
         title: "Unsupported network",
@@ -360,6 +363,7 @@ export const DropdownMenuAdmin = () => {
       });
       return;
     }
+    
     if (chainId !== optimism.id) {
       notifyError({
         title: "Unsupported network",
@@ -369,6 +373,7 @@ export const DropdownMenuAdmin = () => {
       switchChain({ chainId: optimism.id });
       return;
     }
+    
     const response = await setSchema({
       from: address,
       uid: schemaUID as `0x${string}`,
@@ -560,6 +565,7 @@ export const DropdownMenuAdmin = () => {
         switchChain({ chainId: optimism.id });
         return;
       }
+      
       const isRoot = await hasRole(ROLES.ROOT, address);
       if (isRoot) setConnectedRole(ROLES.ROOT);
       else {

--- a/src/components/03-organisms/DropdownMenuAdmin.tsx
+++ b/src/components/03-organisms/DropdownMenuAdmin.tsx
@@ -16,7 +16,7 @@ import { useToast } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { BeatLoader } from "react-spinners";
 import { isAddress } from "viem";
-import { useAccount } from "wagmi";
+import { useAccount, useSwitchChain } from "wagmi";
 
 import { InputAddressUser } from "@/components/02-molecules/";
 import { useNotify } from "@/hooks";
@@ -38,9 +38,10 @@ import {
   MANAGER_OPTIONS,
   ROLES_OPTIONS,
 } from "@/utils/ui-utils";
+import { optimism } from "viem/chains";
 
 export const DropdownMenuAdmin = () => {
-  const { address } = useAccount();
+  const { address, chainId } = useAccount();
   const { push } = useRouter();
   const { notifyError } = useNotify();
   const toast = useToast();
@@ -59,6 +60,7 @@ export const DropdownMenuAdmin = () => {
   const [schemaUID, setSchemaUID] = useState<string | `0x${string}`>("");
   const [action, setAction] = useState<number>(0);
   const { setNewTitleAdded } = useContext(GiveBadgeContext);
+  const { switchChain } = useSwitchChain();
 
   // Updates the validAddress when the inputAddress changes
   useEffect(() => {
@@ -83,6 +85,15 @@ export const DropdownMenuAdmin = () => {
         title: "Please connect first",
         message: "No address found.",
       });
+      return;
+    }
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
       return;
     }
 
@@ -151,6 +162,16 @@ export const DropdownMenuAdmin = () => {
 
   // Call the revokeRole function with the current state values
   const handleRevokeRole = async () => {
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
+
     if (!address || !inputAddress || !role || !validAddress) {
       setIsLoading(false);
       notifyError({
@@ -237,6 +258,15 @@ export const DropdownMenuAdmin = () => {
   };
 
   const handleAttestationTitle = async () => {
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
     if (!address) {
       setIsLoading(false);
       notifyError({
@@ -323,6 +353,15 @@ export const DropdownMenuAdmin = () => {
   };
 
   const handleSetSchema = async () => {
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
     if (!address) {
       setIsLoading(false);
       notifyError({
@@ -395,6 +434,16 @@ export const DropdownMenuAdmin = () => {
   };
 
   const handleRevokeManagerRole = async () => {
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
+
     const queryVariables = {
       where: {
         schemaId: {
@@ -503,6 +552,15 @@ export const DropdownMenuAdmin = () => {
 
   // Defines the connected user to use the admin menu
   const handleConnectedAddress = async () => {
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
     if (address) {
       const isRoot = await hasRole(ROLES.ROOT, address);
       if (isRoot) setConnectedRole(ROLES.ROOT);

--- a/src/components/03-organisms/DropdownMenuAdmin.tsx
+++ b/src/components/03-organisms/DropdownMenuAdmin.tsx
@@ -16,6 +16,7 @@ import { useToast } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { BeatLoader } from "react-spinners";
 import { isAddress } from "viem";
+import { optimism } from "viem/chains";
 import { useAccount, useSwitchChain } from "wagmi";
 
 import { InputAddressUser } from "@/components/02-molecules/";
@@ -38,7 +39,6 @@ import {
   MANAGER_OPTIONS,
   ROLES_OPTIONS,
 } from "@/utils/ui-utils";
-import { optimism } from "viem/chains";
 
 export const DropdownMenuAdmin = () => {
   const { address, chainId } = useAccount();
@@ -162,6 +162,14 @@ export const DropdownMenuAdmin = () => {
 
   // Call the revokeRole function with the current state values
   const handleRevokeRole = async () => {
+    if (!address || !inputAddress || !role || !validAddress) {
+      setIsLoading(false);
+      notifyError({
+        title: "Please connect first",
+        message: "No address found.",
+      });
+      return;
+    }
     if (chainId !== optimism.id) {
       notifyError({
         title: "Unsupported network",
@@ -169,15 +177,6 @@ export const DropdownMenuAdmin = () => {
           "Please switch to the supported network to use this application.",
       });
       switchChain({ chainId: optimism.id });
-      return;
-    }
-
-    if (!address || !inputAddress || !role || !validAddress) {
-      setIsLoading(false);
-      notifyError({
-        title: "Please connect first",
-        message: "No address found.",
-      });
       return;
     }
 
@@ -258,6 +257,14 @@ export const DropdownMenuAdmin = () => {
   };
 
   const handleAttestationTitle = async () => {
+    if (!address) {
+      setIsLoading(false);
+      notifyError({
+        title: "Please connect first",
+        message: "No address found.",
+      });
+      return;
+    }
     if (chainId !== optimism.id) {
       notifyError({
         title: "Unsupported network",
@@ -265,14 +272,6 @@ export const DropdownMenuAdmin = () => {
           "Please switch to the supported network to use this application.",
       });
       switchChain({ chainId: optimism.id });
-      return;
-    }
-    if (!address) {
-      setIsLoading(false);
-      notifyError({
-        title: "Please connect first",
-        message: "No address found.",
-      });
       return;
     }
 
@@ -353,6 +352,14 @@ export const DropdownMenuAdmin = () => {
   };
 
   const handleSetSchema = async () => {
+    if (!address) {
+      setIsLoading(false);
+      notifyError({
+        title: "Please connect first",
+        message: "No address found.",
+      });
+      return;
+    }
     if (chainId !== optimism.id) {
       notifyError({
         title: "Unsupported network",
@@ -362,15 +369,6 @@ export const DropdownMenuAdmin = () => {
       switchChain({ chainId: optimism.id });
       return;
     }
-    if (!address) {
-      setIsLoading(false);
-      notifyError({
-        title: "Please connect first",
-        message: "No address found.",
-      });
-      return;
-    }
-
     const response = await setSchema({
       from: address,
       uid: schemaUID as `0x${string}`,
@@ -552,16 +550,16 @@ export const DropdownMenuAdmin = () => {
 
   // Defines the connected user to use the admin menu
   const handleConnectedAddress = async () => {
-    if (chainId !== optimism.id) {
-      notifyError({
-        title: "Unsupported network",
-        message:
-          "Please switch to the supported network to use this application.",
-      });
-      switchChain({ chainId: optimism.id });
-      return;
-    }
     if (address) {
+      if (chainId !== optimism.id) {
+        notifyError({
+          title: "Unsupported network",
+          message:
+            "Please switch to the supported network to use this application.",
+        });
+        switchChain({ chainId: optimism.id });
+        return;
+      }
       const isRoot = await hasRole(ROLES.ROOT, address);
       if (isRoot) setConnectedRole(ROLES.ROOT);
       else {

--- a/src/components/03-organisms/DropdownMenuAdmin.tsx
+++ b/src/components/03-organisms/DropdownMenuAdmin.tsx
@@ -91,7 +91,7 @@ export const DropdownMenuAdmin = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;
@@ -174,7 +174,7 @@ export const DropdownMenuAdmin = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;
@@ -269,7 +269,7 @@ export const DropdownMenuAdmin = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;
@@ -364,7 +364,7 @@ export const DropdownMenuAdmin = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;
@@ -436,7 +436,7 @@ export const DropdownMenuAdmin = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;
@@ -555,7 +555,7 @@ export const DropdownMenuAdmin = () => {
         notifyError({
           title: "Unsupported network",
           message:
-            "Please switch to the supported network to use this application.",
+            "Please switch to the Optmism network to use this application.",
         });
         switchChain({ chainId: optimism.id });
         return;

--- a/src/components/04-templates/BadgeDetailsSection.tsx
+++ b/src/components/04-templates/BadgeDetailsSection.tsx
@@ -109,7 +109,7 @@ export const BadgeDetailsSection = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;
@@ -196,7 +196,7 @@ export const BadgeDetailsSection = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;
@@ -232,7 +232,7 @@ export const BadgeDetailsSection = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;

--- a/src/components/04-templates/BadgeDetailsSection.tsx
+++ b/src/components/04-templates/BadgeDetailsSection.tsx
@@ -17,7 +17,7 @@ import { useToast } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { BeatLoader } from "react-spinners";
 import { encodeAbiParameters, parseAbiParameters } from "viem";
-import { useAccount } from "wagmi";
+import { useAccount, useSwitchChain } from "wagmi";
 
 import {
   BadgeDetailsNavigation,
@@ -41,9 +41,10 @@ import {
 import { revoke } from "../../lib/service/revoke";
 import { OutboundLinkButton } from "../01-atoms/OutboundLink";
 import { EnsAvatar, EnsName } from "../02-molecules";
+import { optimism } from "viem/chains";
 
 export const BadgeDetailsSection = () => {
-  const { address } = useAccount();
+  const { address, chainId } = useAccount();
   const { selectedBadge } = useBadge();
   const toast = useToast();
   const { notifyError } = useNotify();
@@ -51,6 +52,7 @@ export const BadgeDetailsSection = () => {
   const { setSelectedBadge } = useBadge();
 
   const { villagerAttestationCount } = useContext(WalletContext);
+  const { switchChain } = useSwitchChain();
 
   useEffect(() => {
     if (villagerAttestationCount === 0) {
@@ -103,6 +105,15 @@ export const BadgeDetailsSection = () => {
     response: any,
     isConfirm: boolean | null,
   ) => {
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
     if (response instanceof Error) {
       setLoadingConfirm(false);
       setLoadingDeny(false);
@@ -181,6 +192,16 @@ export const BadgeDetailsSection = () => {
 
   // Submit attestation
   const handleAttest = async (isConfirm: boolean) => {
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
+
     if (!canProcessAttestation()) return;
 
     const data = encodeAbiParameters(
@@ -207,6 +228,15 @@ export const BadgeDetailsSection = () => {
 
   // Submit revoke
   const handleRevoke = async () => {
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
     if (!canProcessAttestation()) return;
     const response = await revoke(
       address as `0x${string}`,

--- a/src/components/04-templates/BadgeDetailsSection.tsx
+++ b/src/components/04-templates/BadgeDetailsSection.tsx
@@ -17,6 +17,7 @@ import { useToast } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { BeatLoader } from "react-spinners";
 import { encodeAbiParameters, parseAbiParameters } from "viem";
+import { optimism } from "viem/chains";
 import { useAccount, useSwitchChain } from "wagmi";
 
 import {
@@ -41,7 +42,6 @@ import {
 import { revoke } from "../../lib/service/revoke";
 import { OutboundLinkButton } from "../01-atoms/OutboundLink";
 import { EnsAvatar, EnsName } from "../02-molecules";
-import { optimism } from "viem/chains";
 
 export const BadgeDetailsSection = () => {
   const { address, chainId } = useAccount();

--- a/src/components/04-templates/CheckoutSection.tsx
+++ b/src/components/04-templates/CheckoutSection.tsx
@@ -90,7 +90,7 @@ export const CheckoutSection = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;
@@ -207,7 +207,7 @@ export const CheckoutSection = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;
@@ -301,7 +301,7 @@ export const CheckoutSection = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;

--- a/src/components/04-templates/CheckoutSection.tsx
+++ b/src/components/04-templates/CheckoutSection.tsx
@@ -25,6 +25,7 @@ import {
 } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { BeatLoader } from "react-spinners";
+import { optimism } from "viem/chains";
 import { encodeAbiParameters, parseAbiParameters } from "viem/utils";
 import { useAccount, useSwitchChain } from "wagmi";
 
@@ -45,7 +46,6 @@ import {
   getReadableData,
   isBytes32,
 } from "@/utils/formatters";
-import { optimism } from "viem/chains";
 
 export const CheckoutSection = () => {
   const { address, chainId } = useAccount();

--- a/src/components/04-templates/CheckoutSection.tsx
+++ b/src/components/04-templates/CheckoutSection.tsx
@@ -26,7 +26,7 @@ import {
 import { useRouter } from "next/navigation";
 import { BeatLoader } from "react-spinners";
 import { encodeAbiParameters, parseAbiParameters } from "viem/utils";
-import { useAccount } from "wagmi";
+import { useAccount, useSwitchChain } from "wagmi";
 
 import { CommentIcon, TheFooterNavbar, TheHeader } from "@/components/01-atoms";
 import { useNotify } from "@/hooks";
@@ -45,15 +45,17 @@ import {
   getReadableData,
   isBytes32,
 } from "@/utils/formatters";
+import { optimism } from "viem/chains";
 
 export const CheckoutSection = () => {
-  const { address } = useAccount();
+  const { address, chainId } = useAccount();
   const toast = useToast();
   const { push } = useRouter();
   const { notifyError } = useNotify();
 
   const { villagerAttestationCount, setVillagerAttestationCount } =
     useContext(WalletContext);
+  const { switchChain } = useSwitchChain();
 
   useEffect(() => {
     if (villagerAttestationCount === 0) push("/pre-checkin");
@@ -84,7 +86,15 @@ export const CheckoutSection = () => {
       });
       return;
     }
-
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
     if (!checkInTxId) {
       setLoading(false);
       notifyError({
@@ -193,6 +203,16 @@ export const CheckoutSection = () => {
 
   // Check the user's check-in timestamp
   const handleQuery = async () => {
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
+
     const queryVariables = {
       where: {
         schemaId: {
@@ -277,7 +297,15 @@ export const CheckoutSection = () => {
       });
       return;
     }
-
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
     if (villagerAttestationCount && villagerAttestationCount > 2) {
       setVillagerAttestationCount(4);
       return;

--- a/src/components/04-templates/GiveBadgeSection.tsx
+++ b/src/components/04-templates/GiveBadgeSection.tsx
@@ -23,7 +23,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { BeatLoader } from "react-spinners";
 import { isAddress, encodeAbiParameters, parseAbiParameters } from "viem";
 import { normalize } from "viem/ens";
-import { useAccount } from "wagmi";
+import { useAccount, useSwitchChain } from "wagmi";
 
 import {
   BadgeDetailsNavigation,
@@ -57,6 +57,7 @@ import { getEllipsedAddress, isBytes32 } from "@/utils/formatters";
 import { wagmiConfig } from "@/wagmi";
 
 import { EnsName, EnsAvatar } from "../02-molecules";
+import { optimism } from "viem/chains";
 
 export enum GiveBadgeStepAddress {
   INSERT_ADDRESS = "INSERT_ADDRESS",
@@ -65,7 +66,7 @@ export enum GiveBadgeStepAddress {
 }
 
 export const GiveBadgeSection = () => {
-  const { address } = useAccount();
+  const { address, chainId } = useAccount();
   const toast = useToast();
   const { push } = useRouter();
   const { notifyError } = useNotify();
@@ -80,6 +81,7 @@ export const GiveBadgeSection = () => {
     inputBadgeTitleList,
   } = useContext(GiveBadgeContext);
   const { villagerAttestationCount } = useContext(WalletContext);
+  const { switchChain } = useSwitchChain();
 
   useEffect(() => {
     if (villagerAttestationCount === 0) {
@@ -151,6 +153,15 @@ export const GiveBadgeSection = () => {
   }, [inputAddress]);
 
   const handleResolveEns = async () => {
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
     if (!inputAddress) return;
     if (!/\.eth$/.test(inputAddress)) {
       setBadgeInputAddress(null);
@@ -268,7 +279,15 @@ export const GiveBadgeSection = () => {
       });
       return;
     }
-
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
     if (!badgeInputAddress) {
       setLoading(false);
       notifyError({

--- a/src/components/04-templates/GiveBadgeSection.tsx
+++ b/src/components/04-templates/GiveBadgeSection.tsx
@@ -157,7 +157,7 @@ export const GiveBadgeSection = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;
@@ -283,7 +283,7 @@ export const GiveBadgeSection = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;

--- a/src/components/04-templates/GiveBadgeSection.tsx
+++ b/src/components/04-templates/GiveBadgeSection.tsx
@@ -22,6 +22,7 @@ import { watchAccount } from "@wagmi/core";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { BeatLoader } from "react-spinners";
 import { isAddress, encodeAbiParameters, parseAbiParameters } from "viem";
+import { optimism } from "viem/chains";
 import { normalize } from "viem/ens";
 import { useAccount, useSwitchChain } from "wagmi";
 
@@ -57,7 +58,6 @@ import { getEllipsedAddress, isBytes32 } from "@/utils/formatters";
 import { wagmiConfig } from "@/wagmi";
 
 import { EnsName, EnsAvatar } from "../02-molecules";
-import { optimism } from "viem/chains";
 
 export enum GiveBadgeStepAddress {
   INSERT_ADDRESS = "INSERT_ADDRESS",
@@ -288,6 +288,7 @@ export const GiveBadgeSection = () => {
       switchChain({ chainId: optimism.id });
       return;
     }
+
     if (!badgeInputAddress) {
       setLoading(false);
       notifyError({

--- a/src/components/04-templates/GiveBadgeSection.tsx
+++ b/src/components/04-templates/GiveBadgeSection.tsx
@@ -153,15 +153,6 @@ export const GiveBadgeSection = () => {
   }, [inputAddress]);
 
   const handleResolveEns = async () => {
-    if (chainId !== optimism.id) {
-      notifyError({
-        title: "Unsupported network",
-        message:
-          "Please switch to the Optmism network to use this application.",
-      });
-      switchChain({ chainId: optimism.id });
-      return;
-    }
     if (!inputAddress) return;
     if (!/\.eth$/.test(inputAddress)) {
       setBadgeInputAddress(null);
@@ -279,6 +270,7 @@ export const GiveBadgeSection = () => {
       });
       return;
     }
+    
     if (chainId !== optimism.id) {
       notifyError({
         title: "Unsupported network",
@@ -306,6 +298,7 @@ export const GiveBadgeSection = () => {
       });
       return;
     }
+    
     let encodeParam = "";
     let encodeArgs: string[] = [];
     if (inputBadge.uid === ZUVILLAGE_SCHEMAS.ATTEST_MANAGER.uid) {

--- a/src/components/04-templates/MyBadgeSection.tsx
+++ b/src/components/04-templates/MyBadgeSection.tsx
@@ -3,7 +3,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { Box, Flex } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { BeatLoader } from "react-spinners";
-import { useAccount } from "wagmi";
+import { useAccount, useSwitchChain } from "wagmi";
 
 import {
   BadgeCard,
@@ -19,6 +19,7 @@ import { fetchEASData } from "@/lib/service/fetchEASData";
 
 import { type BadgeData } from "../01-atoms/BadgeCard";
 import { type Schema } from "../01-atoms/BadgeCard";
+import { optimism } from "viem/chains";
 
 interface Attestation {
   decodedDataJson: string;
@@ -34,11 +35,12 @@ interface Attestation {
 }
 
 export const MyBadgeSection: React.FC = () => {
-  const { address } = useAccount();
+  const { address, chainId } = useAccount();
   const { notifyError } = useNotify();
   const { push } = useRouter();
 
   const { villagerAttestationCount } = useContext(WalletContext);
+  const { switchChain } = useSwitchChain();
 
   useEffect(() => {
     if (villagerAttestationCount === 0) {
@@ -148,6 +150,15 @@ export const MyBadgeSection: React.FC = () => {
     recipient: string | null,
     attestation: string | null,
   ) => {
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
+      return;
+    }
     let queryVariables = {};
     queryVariables = {
       where: {

--- a/src/components/04-templates/MyBadgeSection.tsx
+++ b/src/components/04-templates/MyBadgeSection.tsx
@@ -3,6 +3,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { Box, Flex } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { BeatLoader } from "react-spinners";
+import { optimism } from "viem/chains";
 import { useAccount, useSwitchChain } from "wagmi";
 
 import {
@@ -19,7 +20,6 @@ import { fetchEASData } from "@/lib/service/fetchEASData";
 
 import { type BadgeData } from "../01-atoms/BadgeCard";
 import { type Schema } from "../01-atoms/BadgeCard";
-import { optimism } from "viem/chains";
 
 interface Attestation {
   decodedDataJson: string;

--- a/src/components/04-templates/MyBadgeSection.tsx
+++ b/src/components/04-templates/MyBadgeSection.tsx
@@ -4,7 +4,7 @@ import { Box, Flex } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { BeatLoader } from "react-spinners";
 import { optimism } from "viem/chains";
-import { useAccount, useSwitchChain } from "wagmi";
+import { useAccount } from "wagmi";
 
 import {
   BadgeCard,
@@ -40,7 +40,6 @@ export const MyBadgeSection: React.FC = () => {
   const { push } = useRouter();
 
   const { villagerAttestationCount } = useContext(WalletContext);
-  const { switchChain } = useSwitchChain();
 
   useEffect(() => {
     if (villagerAttestationCount === 0) {
@@ -150,15 +149,6 @@ export const MyBadgeSection: React.FC = () => {
     recipient: string | null,
     attestation: string | null,
   ) => {
-    if (chainId !== optimism.id) {
-      notifyError({
-        title: "Unsupported network",
-        message:
-          "Please switch to the Optmism network to use this application.",
-      });
-      switchChain({ chainId: optimism.id });
-      return;
-    }
     let queryVariables = {};
     queryVariables = {
       where: {

--- a/src/components/04-templates/MyBadgeSection.tsx
+++ b/src/components/04-templates/MyBadgeSection.tsx
@@ -154,7 +154,7 @@ export const MyBadgeSection: React.FC = () => {
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
+          "Please switch to the Optmism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;

--- a/src/components/04-templates/MyBadgeSection.tsx
+++ b/src/components/04-templates/MyBadgeSection.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useEffect, useState } from "react";
 import { Box, Flex } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { BeatLoader } from "react-spinners";
-import { optimism } from "viem/chains";
 import { useAccount } from "wagmi";
 
 import {
@@ -35,7 +34,7 @@ interface Attestation {
 }
 
 export const MyBadgeSection: React.FC = () => {
-  const { address, chainId } = useAccount();
+  const { address } = useAccount();
   const { notifyError } = useNotify();
   const { push } = useRouter();
 

--- a/src/lib/context/GiveBadgeContext.tsx
+++ b/src/lib/context/GiveBadgeContext.tsx
@@ -84,7 +84,6 @@ export const GiveBadgeContextProvider = ({
 
   const { switchChain } = useSwitchChain();
   const { chainId, address } = useAccount();
-  const { chainId, address } = useAccount();
   const { notifyError } = useNotify();
 
   useEffect(() => {

--- a/src/lib/context/GiveBadgeContext.tsx
+++ b/src/lib/context/GiveBadgeContext.tsx
@@ -9,8 +9,7 @@ import React, {
 } from "react";
 
 import { optimism } from "viem/chains";
-import { optimism } from "viem/chains";
-import { useAccount, useSwitchChain, useSwitchChain } from "wagmi";
+import { useAccount, useSwitchChain } from "wagmi";
 
 import { GiveBadgeStepAddress } from "@/components/04-templates/GiveBadgeSection";
 import { useNotify } from "@/hooks";
@@ -84,9 +83,8 @@ export const GiveBadgeContextProvider = ({
   }, [badgeInputAddress, addressStep, inputBadgeTitleList, newTitleAdded]);
 
   const { switchChain } = useSwitchChain();
-  const { chainId, address, chainId } = useAccount();
+  const { chainId, address } = useAccount();
   const { notifyError } = useNotify();
-  const { switchChain } = useSwitchChain();
 
   useEffect(() => {
     if (address) {
@@ -107,16 +105,7 @@ export const GiveBadgeContextProvider = ({
       notifyError({
         title: "Unsupported network",
         message:
-          "Please switch to the supported network to use this application.",
-      });
-      switchChain({ chainId: optimism.id });
-      return;
-    }
-
-    if (chainId !== optimism.id) {
-      notifyError({
-        title: "Unsupported network",
-        message: "Please switch to Optimism network to use this application.",
+          "Please switch to the Optimism network to use this application.",
       });
       switchChain({ chainId: optimism.id });
       return;

--- a/src/lib/context/GiveBadgeContext.tsx
+++ b/src/lib/context/GiveBadgeContext.tsx
@@ -8,13 +8,14 @@ import React, {
   useEffect,
 } from "react";
 
-import { useAccount } from "wagmi";
+import { useAccount, useSwitchChain } from "wagmi";
 
 import { GiveBadgeStepAddress } from "@/components/04-templates/GiveBadgeSection";
 import { useNotify } from "@/hooks";
 import { ROLES, ZUVILLAGE_SCHEMAS } from "@/lib/client/constants";
 import { hasRole, getAllAttestationTitles } from "@/lib/service";
 import { EthereumAddress } from "@/lib/shared/types";
+import { optimism } from "viem/chains";
 
 interface GiveBadgeContextProps {
   badgeInputAddress: EthereumAddress | null;
@@ -81,8 +82,9 @@ export const GiveBadgeContextProvider = ({
     });
   }, [badgeInputAddress, addressStep, inputBadgeTitleList, newTitleAdded]);
 
-  const { address } = useAccount();
+  const { address, chainId } = useAccount();
   const { notifyError } = useNotify();
+  const { switchChain } = useSwitchChain();
 
   useEffect(() => {
     if (address) {
@@ -96,6 +98,16 @@ export const GiveBadgeContextProvider = ({
         title: "No account connected",
         message: "Please connect your wallet.",
       });
+      return;
+    }
+
+    if (chainId !== optimism.id) {
+      notifyError({
+        title: "Unsupported network",
+        message:
+          "Please switch to the supported network to use this application.",
+      });
+      switchChain({ chainId: optimism.id });
       return;
     }
 

--- a/src/lib/context/GiveBadgeContext.tsx
+++ b/src/lib/context/GiveBadgeContext.tsx
@@ -8,6 +8,7 @@ import React, {
   useEffect,
 } from "react";
 
+import { optimism } from "viem/chains";
 import { useAccount, useSwitchChain } from "wagmi";
 
 import { GiveBadgeStepAddress } from "@/components/04-templates/GiveBadgeSection";
@@ -15,7 +16,6 @@ import { useNotify } from "@/hooks";
 import { ROLES, ZUVILLAGE_SCHEMAS } from "@/lib/client/constants";
 import { hasRole, getAllAttestationTitles } from "@/lib/service";
 import { EthereumAddress } from "@/lib/shared/types";
-import { optimism } from "viem/chains";
 
 interface GiveBadgeContextProps {
   badgeInputAddress: EthereumAddress | null;

--- a/src/lib/context/WalletContext.tsx
+++ b/src/lib/context/WalletContext.tsx
@@ -10,7 +10,7 @@ import React, {
 } from "react";
 
 import { watchAccount } from "@wagmi/core";
-import { useAccount } from "wagmi";
+import { useAccount, useSwitchChain } from "wagmi";
 
 import { useNotify } from "@/hooks/useNotify";
 import { ZUVILLAGE_SCHEMAS, ROLES } from "@/lib/client/constants";
@@ -19,6 +19,7 @@ import { fetchEASData } from "@/lib/service/fetchEASData";
 import { hasRole } from "@/lib/service/hasRole";
 import { getEllipsedAddress } from "@/utils/formatters";
 import { wagmiConfig } from "@/wagmi";
+import { optimism } from "viem/chains";
 
 interface WalletContextProps {
   villagerAttestationCount: number | null;
@@ -56,11 +57,12 @@ export const WalletContextProvider = ({
     });
   }, [villagerAttestationCount]);
 
-  const { address } = useAccount();
+  const { address, chainId } = useAccount();
   const { notifyError, notifySuccess } = useNotify();
   const unwatch = watchAccount(wagmiConfig, {
     onChange() {},
   });
+  const { switchChain } = useSwitchChain();
 
   useEffect(() => {
     // First Time user in page
@@ -87,6 +89,15 @@ export const WalletContextProvider = ({
   const handleQuery = async () => {
     // If the user is ROOT we skip the checkin validation
     if (address) {
+      if (chainId !== optimism.id) {
+        notifyError({
+          title: "Unsupported network",
+          message:
+            "Please switch to the supported network to use this application.",
+        });
+        switchChain({ chainId: optimism.id });
+        return;
+      }
       const isRoot = await hasRole(ROLES.ROOT, address);
       if (isRoot) {
         setVillagerAttestationCount(2);

--- a/src/lib/context/WalletContext.tsx
+++ b/src/lib/context/WalletContext.tsx
@@ -93,7 +93,7 @@ export const WalletContextProvider = ({
         notifyError({
           title: "Unsupported network",
           message:
-            "Please switch to the supported network to use this application.",
+            "Please switch to the Optmism network to use this application.",
         });
         switchChain({ chainId: optimism.id });
         return;

--- a/src/lib/context/WalletContext.tsx
+++ b/src/lib/context/WalletContext.tsx
@@ -10,6 +10,7 @@ import React, {
 } from "react";
 
 import { watchAccount } from "@wagmi/core";
+import { optimism } from "viem/chains";
 import { useAccount, useSwitchChain } from "wagmi";
 
 import { useNotify } from "@/hooks/useNotify";
@@ -19,7 +20,6 @@ import { fetchEASData } from "@/lib/service/fetchEASData";
 import { hasRole } from "@/lib/service/hasRole";
 import { getEllipsedAddress } from "@/utils/formatters";
 import { wagmiConfig } from "@/wagmi";
-import { optimism } from "viem/chains";
 
 interface WalletContextProps {
   villagerAttestationCount: number | null;


### PR DESCRIPTION
Added the checking below before each blockchain call
closes #126 

``` typescript
 if (chainId !== optimism.id) {
      notifyError({
        title: "Unsupported network",
        message:
          "Please switch to the supported network to use this application.",
      });
      switchChain({ chainId: optimism.id });
      return;
    }
```